### PR TITLE
Add sample with USB cam

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,11 +29,12 @@ set(CUDA_NVCC_FLAGS
 
 if (${CUDA_VERSION} VERSION_GREATER  "7.0" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "5.0")
   set(CUDA_NVCC_FLAGS --ptxas-options=-v -std=c++11 --use_fast_math -lcufft -Xcompiler "-w" -lcublas)
-elseif(${CUDA_VERSION} MATCHES "8.0")
+elseif(${CUDA_VERSION} VERSION_GREATER "8.0")
   set(CUDA_NVCC_FLAGS --ptxas-options=-v --use_fast_math -lcufft -Xcompiler "-w" -lcublas)
 endif()
 
 set(CAFFE_INCLUDEDIR 
+  $ENV{CAFFE_ROOT}/.build_release/src
   $ENV{CAFFE_ROOT}/include 
   $ENV{CAFFE_ROOT}/distribute/include 
   $ENV{CAFFE_ROOT}/build/include)

--- a/samples/sample_kernelized_correlation_filters_gpu.launch
+++ b/samples/sample_kernelized_correlation_filters_gpu.launch
@@ -1,0 +1,21 @@
+<launch>
+
+  <include file="$(find roseus_tutorials)/launch/usb-camera.launch" />
+
+  <include file="$(find kernelized_correlation_filters_gpu)/launch/kernelized_correlation_filters_gpu.launch">
+    <arg name="image" value="/image_color" />
+  </include>
+
+  <node name="image_view2"
+        pkg="image_view2" type="image_view2"
+        clear_params="true">
+    <remap from="image" to="/image_color" />
+  </node>
+
+  <node name="image_view"
+        pkg="image_view" type="image_view"
+        clear_params="true">
+    <remap from="image" to="/target" />
+  </node>
+
+</launch>


### PR DESCRIPTION
I tested on Ubuntu 16.04.

![sample_kernelized_correlation_filters_gpu_5fps](https://user-images.githubusercontent.com/4310419/38484519-d7cd9a60-3c11-11e8-9fa2-0c4ac55ea97e.gif)

## Installation & Usage

```
# init workspace
mkdir -p ~/kernelized_correlation_filters_gpu
cd ~/kernelized_correlation_filters_gpu
mkdir src
catkin init
catkin config --merge-devel

# install opencv3
sudo apt install ros-kinetic-opencv3

# install caffe
git clone https://github.com/BVLC/caffe.git
cd caffe
cp Makefile.config.example Makefile.config
vim Makefile.config   # edit it
make -j
export CAFFE_ROOT=$(pwd)

# install kernelized_correlation_filters_gpu
cd ~/kernelized_correlation_filters_gpu/src
git clone https://github.com/wkentaro/kernelized_correlation_filters_gpu.git -b usbcam_sample_ubuntu1604
catkin build

roslaunch kernelized_correlation_filters_gpu sample_kernelized_correlation_filters_gpu.launch
# then select rectangle on image_view2
```